### PR TITLE
feat: Game state machine implementation

### DIFF
--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -10,6 +10,7 @@ pub mod enemies;
 pub mod map;
 pub mod network;
 pub mod progression;
+pub mod state;
 pub mod ui;
 
 /// Plugin that registers all game systems
@@ -18,6 +19,7 @@ pub struct GameSystemsPlugin;
 impl Plugin for GameSystemsPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((
+            state::StatePlugin,
             network::NetworkPlugin,
             combat::CombatPlugin,
             enemies::EnemiesPlugin,

--- a/src/game/state/components.rs
+++ b/src/game/state/components.rs
@@ -1,0 +1,75 @@
+//! State components and resources
+
+use bevy::prelude::*;
+
+/// Resource tracking run statistics
+#[derive(Resource, Debug, Default, Clone)]
+pub struct RunStats {
+    /// Time elapsed in current run (seconds)
+    pub elapsed_time: f32,
+    /// Number of enemies killed this run
+    pub enemies_killed: u32,
+    /// Maximum territory coverage achieved
+    pub max_territory: f32,
+    /// Total nutrients collected this run
+    pub nutrients_collected: f32,
+}
+
+impl RunStats {
+    /// Reset all stats to zero for a new run
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// Resource tracking pause state details
+#[derive(Resource, Debug, Default)]
+pub struct PauseState {
+    /// Whether the pause was triggered by upgrade selection
+    pub was_paused_by_upgrade: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run_stats_default() {
+        let stats = RunStats::default();
+        assert_eq!(stats.elapsed_time, 0.0);
+        assert_eq!(stats.enemies_killed, 0);
+        assert_eq!(stats.max_territory, 0.0);
+        assert_eq!(stats.nutrients_collected, 0.0);
+    }
+
+    #[test]
+    fn test_run_stats_is_resource() {
+        fn assert_resource<T: Resource>() {}
+        assert_resource::<RunStats>();
+    }
+
+    #[test]
+    fn test_run_stats_reset() {
+        let mut stats = RunStats {
+            elapsed_time: 100.0,
+            enemies_killed: 50,
+            max_territory: 0.5,
+            nutrients_collected: 1000.0,
+        };
+        stats.reset();
+        assert_eq!(stats.elapsed_time, 0.0);
+        assert_eq!(stats.enemies_killed, 0);
+    }
+
+    #[test]
+    fn test_pause_state_default() {
+        let pause = PauseState::default();
+        assert!(!pause.was_paused_by_upgrade);
+    }
+
+    #[test]
+    fn test_pause_state_is_resource() {
+        fn assert_resource<T: Resource>() {}
+        assert_resource::<PauseState>();
+    }
+}

--- a/src/game/state/mod.rs
+++ b/src/game/state/mod.rs
@@ -1,0 +1,143 @@
+//! Game state management
+//!
+//! Handles state transitions, pause functionality, and run statistics.
+
+use bevy::prelude::*;
+
+use crate::GameState;
+
+pub mod components;
+pub mod systems;
+
+pub use components::*;
+
+/// Plugin for game state management
+pub struct StatePlugin;
+
+impl Plugin for StatePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<RunStats>()
+            .init_resource::<PauseState>()
+            // Pause input works in Playing and Paused states
+            .add_systems(
+                Update,
+                systems::handle_pause_input
+                    .run_if(in_state(GameState::Playing).or(in_state(GameState::Paused))),
+            )
+            // Update run time only in Playing state
+            .add_systems(
+                Update,
+                systems::update_run_time.run_if(in_state(GameState::Playing)),
+            )
+            // Reset stats when entering Playing (new run)
+            .add_systems(OnEnter(GameState::Playing), systems::reset_run_stats);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::GameState;
+    use bevy::input::InputPlugin;
+    use bevy::state::app::StatesPlugin;
+
+    /// Helper to create test app with state plugin
+    fn create_test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(InputPlugin)
+            .add_plugins(StatesPlugin)
+            .init_state::<GameState>()
+            .add_plugins(StatePlugin);
+        app
+    }
+
+    #[test]
+    fn test_state_plugin_builds() {
+        let mut app = create_test_app();
+        app.update();
+    }
+
+    #[test]
+    fn test_run_stats_resource_exists() {
+        let mut app = create_test_app();
+        app.update();
+
+        assert!(app.world().get_resource::<RunStats>().is_some());
+    }
+
+    #[test]
+    fn test_game_starts_in_menu() {
+        let mut app = create_test_app();
+        app.update();
+
+        let state = app.world().resource::<State<GameState>>();
+        assert_eq!(**state, GameState::Menu);
+    }
+
+    #[test]
+    fn test_state_can_transition_to_playing() {
+        let mut app = create_test_app();
+
+        app.world_mut()
+            .resource_mut::<NextState<GameState>>()
+            .set(GameState::Playing);
+        app.update();
+        app.update();
+
+        let state = app.world().resource::<State<GameState>>();
+        assert_eq!(**state, GameState::Playing);
+    }
+
+    #[test]
+    fn test_state_can_transition_to_paused() {
+        let mut app = create_test_app();
+
+        app.world_mut()
+            .resource_mut::<NextState<GameState>>()
+            .set(GameState::Paused);
+        app.update();
+        app.update();
+
+        let state = app.world().resource::<State<GameState>>();
+        assert_eq!(**state, GameState::Paused);
+    }
+
+    #[test]
+    fn test_pause_state_tracks_upgrade_pause() {
+        let mut app = create_test_app();
+        app.update();
+
+        // Verify we can track if pause was from upgrade
+        {
+            let mut pause_state = app.world_mut().resource_mut::<PauseState>();
+            pause_state.was_paused_by_upgrade = true;
+        }
+
+        let pause_state = app.world().resource::<PauseState>();
+        assert!(pause_state.was_paused_by_upgrade);
+    }
+
+    #[test]
+    fn test_run_stats_reset_on_playing_enter() {
+        let mut app = create_test_app();
+
+        // Modify run stats
+        {
+            let mut stats = app.world_mut().resource_mut::<RunStats>();
+            stats.enemies_killed = 100;
+            stats.elapsed_time = 500.0;
+        }
+
+        // Transition to Playing (should reset)
+        app.world_mut()
+            .resource_mut::<NextState<GameState>>()
+            .set(GameState::Playing);
+        app.update();
+
+        let stats = app.world().resource::<RunStats>();
+        assert_eq!(stats.enemies_killed, 0);
+        // elapsed_time may have small delta from update, check it's close to 0
+        assert!(stats.elapsed_time < 0.1);
+    }
+}

--- a/src/game/state/systems.rs
+++ b/src/game/state/systems.rs
@@ -1,0 +1,64 @@
+//! State systems
+
+use bevy::prelude::*;
+
+use super::components::{PauseState, RunStats};
+use crate::GameState;
+
+/// Handle pause input (Escape key)
+pub fn handle_pause_input(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    current_state: Res<State<GameState>>,
+    mut next_state: ResMut<NextState<GameState>>,
+    mut pause_state: ResMut<PauseState>,
+) {
+    if keyboard.just_pressed(KeyCode::Escape) {
+        match **current_state {
+            GameState::Playing => {
+                pause_state.was_paused_by_upgrade = false;
+                next_state.set(GameState::Paused);
+            }
+            GameState::Paused => {
+                // Only unpause if not paused for upgrade
+                if !pause_state.was_paused_by_upgrade {
+                    next_state.set(GameState::Playing);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Reset run stats when entering Playing state
+pub fn reset_run_stats(mut run_stats: ResMut<RunStats>) {
+    run_stats.reset();
+}
+
+/// Update elapsed time during gameplay
+pub fn update_run_time(time: Res<Time>, mut run_stats: ResMut<RunStats>) {
+    run_stats.elapsed_time += time.delta_secs();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reset_run_stats_system() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .insert_resource(RunStats {
+                elapsed_time: 100.0,
+                enemies_killed: 50,
+                max_territory: 0.5,
+                nutrients_collected: 1000.0,
+            })
+            .add_systems(Update, reset_run_stats);
+
+        app.update();
+
+        let stats = app.world().resource::<RunStats>();
+        assert_eq!(stats.elapsed_time, 0.0);
+        assert_eq!(stats.enemies_killed, 0);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the game state management system for Mycelia.

## Changes

### Resources
- `RunStats`: Tracks elapsed time, enemies killed, territory coverage, nutrients collected
- `PauseState`: Tracks whether pause was triggered by upgrade selection

### Systems
- `handle_pause_input`: Escape key toggles between Playing and Paused states
- `reset_run_stats`: Resets all stats when entering Playing state (new run)
- `update_run_time`: Updates elapsed time during gameplay

### State Machine
- Menu (default start state)
- Playing (active gameplay)
- Paused (true pause - systems don't run)
- Upgrading (pauses with special flag)
- GameOver (end state)

## Test Plan
- [x] 14 unit/integration tests pass
- [x] State transitions work correctly
- [x] Run stats reset on new game
- [x] Clippy clean
- [x] Formatted

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)